### PR TITLE
[DVDD-209] 🔧 package.json - upgrade package versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,19 +18,19 @@
   "author": "Thomas Gerbouin",
   "license": "ISC",
   "peerDependencies": {
-    "typescript": ">= 3",
-    "eslint": ">= 6"
+    "typescript": ">=3.3.1",
+    "eslint": ">=7.1.0"
   },
   "dependencies": {
-    "@typescript-eslint/parser": "^4.22.0",
+    "@typescript-eslint/eslint-plugin": "^5.59.9",
+    "@typescript-eslint/parser": "^5.59.9",
     "eslint-config-airbnb-base": "^14.2.1",
     "eslint-config-prettier": "^8.2.0",
-    "@typescript-eslint/eslint-plugin": "^4.22.0",
-    "eslint-plugin-import": "^2.22.1",
-    "eslint-import-resolver-typescript": "^2.4.0"
+    "eslint-import-resolver-typescript": "^3.5.5",
+    "eslint-plugin-import": "^2.27.5"
   },
   "devDependencies": {
-    "typescript": "^4.2.4",
-    "eslint": "^7.24.0"
+    "eslint": "^8.42.0",
+    "typescript": "^5.1.3"
   }
 }


### PR DESCRIPTION
# Context

Upgrading TS version in the toolbox triggers a warning for the rule `@typescript-eslint/no-unused-vars` for decorators.

It looks like it's a known issue: https://stackoverflow.com/a/73593347

The fix is to upgrade `@typescript-eslint/*` packages.

I also upgraded TS and other packages since we are here.
