### PR TITLE
✨ [DVDD-1033] Rules - disable `no-use-before-define` rule

### DIFF
--- a/index.js
+++ b/index.js
@@ -19,7 +19,7 @@ module.exports = {
     },
   },
   rules: {
-    "prettier/prettier": "error",
+    'prettier/prettier': 'error',
 
     /* Javascript */
     'max-lines': [
@@ -45,6 +45,7 @@ module.exports = {
     'no-await-in-loop': 'off',
     // Allows dependency injections into classes with empty constructors.
     'no-useless-constructor': 'off',
+    'no-use-before-define': 'off',
 
     /* Import */
 


### PR DESCRIPTION
# Changes

While previously updating the linter, we decided to remove the rule `no-use-before-define`. I just realized it's part of the airbnb config, so we need to explicitly disable it.