### PR TITLE
[DVDD-1053] 🔧 Eslint - Harmonize config

### DIFF
--- a/index.js
+++ b/index.js
@@ -18,12 +18,7 @@ module.exports = {
     sourceType: 'module',
     project: 'tsconfig.json',
   },
-  plugins: [
-    '@typescript-eslint/eslint-plugin',
-    '@typescript-eslint',
-    'import',
-    'prettier',
-  ],
+  plugins: ['@typescript-eslint/eslint-plugin', 'import', 'prettier'],
   settings: {
     'import/resolver': {
       typescript: {},

--- a/index.js
+++ b/index.js
@@ -1,4 +1,10 @@
 module.exports = {
+  ignorePatterns: ['.eslintrc.js'],
+  env: {
+    node: true,
+    jest: true,
+  },
+  root: true,
   extends: [
     'airbnb-base',
     'plugin:@typescript-eslint/recommended',
@@ -12,7 +18,12 @@ module.exports = {
     sourceType: 'module',
     project: 'tsconfig.json',
   },
-  plugins: ['@typescript-eslint', 'import'],
+  plugins: [
+    '@typescript-eslint/eslint-plugin',
+    '@typescript-eslint',
+    'import',
+    'prettier',
+  ],
   settings: {
     'import/resolver': {
       typescript: {},

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   "peerDependencies": {
     "eslint": ">=8.51.0",
     "prettier": ">=3.0.3",
-    "typescript": ">=5.2.2"
+    "typescript": ">=5.0.4 <5.3.0"
   },
   "dependencies": {
     "@typescript-eslint/eslint-plugin": "^6.7.5",

--- a/package.json
+++ b/package.json
@@ -19,22 +19,22 @@
   "author": "Thomas Gerbouin",
   "license": "ISC",
   "peerDependencies": {
-    "eslint": ">=7.1.0",
-    "prettier": ">=3.0.0",
-    "typescript": ">=3.3.1"
+    "eslint": ">=8.51.0",
+    "prettier": ">=3.0.3",
+    "typescript": ">=5.2.2"
   },
   "dependencies": {
-    "@typescript-eslint/eslint-plugin": "^5.59.9",
-    "@typescript-eslint/parser": "^5.59.9",
-    "eslint-config-airbnb-base": "^14.2.1",
-    "eslint-config-prettier": "^8.2.0",
-    "eslint-import-resolver-typescript": "^3.5.5",
-    "eslint-plugin-import": "^2.27.5",
-    "eslint-plugin-prettier": "^5.0.0"
+    "@typescript-eslint/eslint-plugin": "^6.7.5",
+    "@typescript-eslint/parser": "^6.7.5",
+    "eslint-config-airbnb-base": "^15.0.0",
+    "eslint-config-prettier": "^9.0.0",
+    "eslint-import-resolver-typescript": "^3.6.1",
+    "eslint-plugin-import": "^2.28.1",
+    "eslint-plugin-prettier": "^5.0.1"
   },
   "devDependencies": {
-    "eslint": "^8.42.0",
-    "prettier": "^3.0.0",
-    "typescript": "^5.1.3"
+    "eslint": "^8.51.0",
+    "prettier": "^3.0.3",
+    "typescript": "^5.2.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   "peerDependencies": {
     "eslint": ">=8.51.0",
     "prettier": ">=3.0.3",
-    "typescript": ">=5.0.4 <5.3.0"
+    "typescript": ">=4.3.5 <5.3.0"
   },
   "dependencies": {
     "@typescript-eslint/eslint-plugin": "^6.7.5",


### PR DESCRIPTION
Première PR nécéssaire afin de publier une nouvelle version de la config eslint pour l'appliquer aux autres repo.
En conséquence, le fichier estlintrc.js revient à  :
`module.exports = {
  extends: ['@gads-citron/eslint-config-citron']
};
`