### PR TITLE
[DVDD-1053] 🔧 Rules - allow importing sub packages

### DIFF
--- a/index.js
+++ b/index.js
@@ -58,7 +58,7 @@ module.exports = {
     // Specify the file extension when importing only if not .ts
     'import/extensions': [
       'error',
-      'always',
+      'ignorePackages',
       {
         ts: 'never',
       },


### PR DESCRIPTION
This is necessary to remove errors when importing from a package that exposes subfolders.

Example of error that will be removed once this is merged:  
```
import {  WorkflowType } from '@gads-citron/tech-contracts/workflows'
```
